### PR TITLE
cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,32 @@
 
 Generate a hash representing the stats of this module files and all its descendents files.
 
+
 ```js
 var hashForDep = require('hash-for-dep');
 
 hashForDep('rsvp'); // if RSVP is a dependency of the current project, you will get a checksum for it
 hashForDep('rsvp', 'path/to/other/project'); //  you will get a checksum for RSVP resolved relative to the provided root
+```
+
+## Cache
+
+NOTE: By default, these hashes are cached for the life of the process. As this
+is the same strategy node uses for `require(x)` we can safely follow suite.
+
+That being said, some scenarios may exist where this is not wanted. So just
+like `require._cache` exists, we provide the following options:
+
+#### To evict the cache manually (maybe for testing)
+
+```js
+require('hash-for-dep')._resetCache();
+```
+
+#### To opt out of the cache on a per invocation basis
+
+```js
+var hashForDep = require('hash-for-dep');
+
+hashForDep(name, path, null, false /* this mysterious argument should be set to false */);
 ```

--- a/index.js
+++ b/index.js
@@ -3,41 +3,80 @@ var helpers = require('broccoli-kitchen-sink-helpers');
 var crypto = require('crypto');
 var statPathsFor = require('./lib/stat-paths-for');
 var heimdall = require('heimdalljs');
+var Cache = require('./lib/cache');
+var cacheKey = require('./lib/cache-key');
+
+var CACHE = new Cache();
 
 function HashForDepSchema() {
   this.paths = 0;
 }
 
+function cacheGet(key) {
+  return CACHE[key]
+}
+
+function cacheGet(key) {
+  return CACHE[key]
+}
+
+function cacheSet(key, value) {
+  CACHE[key] = value;
+  return value;
+}
 /* @public
  *
  * @method hashForDep
  * @param {String} name name of the dependency
  * @param {String} dir (optional) root dir to run the hash resolving from
  * @param {String} _hashTreeOverride (optional) private, used internally for testing
+ * @param {Boolean} _skipCache (optional) intended to bypass cache
  * @return {String} a hash representing the stats of this module and all its descendents
  */
-module.exports = function hashForDep(name, dir, _hashTreeOverride) {
+module.exports = function hashForDep(name, dir, _hashTreeOverride, _skipCache) {
+  var skipCache = false;
+  var cacheKey, hash;
+
+  if (typeof _hashTreeOverride === 'function' || _skipCache === true) {
+    skipCache = true;
+  } else {
+    cacheKey = module.exports.cacheKey(name, dir);
+  }
+
   var heimdallNodeOptions = {
     name: 'hashForDep(' + name + ')',
     hashForDep: true,
     dependencyName: name,
-    rootDir: dir
+    rootDir: dir,
+    skipCache: skipCache,
+    cacheKey: cacheKey
   };
 
   var heimdallNode = heimdall.start(heimdallNodeOptions, HashForDepSchema);
 
-  var inputHashes = statPathsFor(name, dir).map(function(statPath) {
-    var hashFn = _hashTreeOverride || helpers.hashTree;
+  if (CACHE.has(cacheKey)) {
+    hash = CACHE.get(cacheKey);
+  } else {
+    var inputHashes = statPathsFor(name, dir).map(function(statPath) {
+      var hashFn = _hashTreeOverride || helpers.hashTree;
 
-    heimdallNode.stats.paths++;
+      heimdallNode.stats.paths++;
 
-    return hashFn(statPath);
-  }).join(0x00);
+      return hashFn(statPath);
+    }).join(0x00);
 
-  var hash = crypto.createHash('sha1').
+    hash = crypto.createHash('sha1').
       update(inputHashes).digest('hex');
+  }
 
   heimdallNode.stop();
-
   return hash;
+};
+
+module.exports._resetCache = function() {
+  CACHE = new Cache();
+};
+
+module.exports._cache = function() {
+  return CACHE;
 };

--- a/lib/cache-key.js
+++ b/lib/cache-key.js
@@ -1,0 +1,8 @@
+'use strict';
+var crypto = require('crypto');
+
+module.exports = function cacheKey(name, dir, _hashTreeOverride) {
+  var value = name + 0x00 + dir + 0x00 + (typeof _hashTreeOverride === 'function');
+
+  return crypto.createHash('sha1').update(value).digest('hex');
+};

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -33,3 +33,9 @@ Cache.prototype.has = function(key) {
 Cache.prototype.delete = function(key) {
   delete this._store[key];
 };
+
+Object.defineProperty(Cache.prototype, 'size', {
+  get: function() {
+    return Object.keys(this._store).length;
+  }
+});

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,35 @@
+'use strict';
+
+function makeCache() {
+  // object with no prototype
+  var cache = Object.create(null);
+
+  // force the jit to immediately realize this object is a dictionary. This
+  // should prevent the JIT from going wastefully one direction (fast mode)
+  // then going another (dict mode) after
+  cache['foo'] = 1;
+  delete cache['foo'];
+
+  return cache;
+}
+
+module.exports = Cache;
+function Cache() {
+  this._store = makeCache();
+}
+
+Cache.prototype.set = function(key, value) {
+  return this._store[key] = value;
+};
+
+Cache.prototype.get = function(key) {
+  return this._store[key];
+};
+
+Cache.prototype.has = function(key) {
+  return key in this._store;
+};
+
+Cache.prototype.delete = function(key) {
+  delete this._store[key];
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "resolve": "^1.1.6"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "mocha": "^2.2.4",
     "mocha-jshint": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.3.1",
     "heimdalljs": "^0.2.3",
+    "heimdalljs-logger": "^0.1.7",
     "resolve": "^1.1.6"
   },
   "devDependencies": {

--- a/tests/cache-key-test.js
+++ b/tests/cache-key-test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var expect = require('chai').expect;
+var cacheKey = require('../lib/cache-key');
+
+describe('cacheKey', function() {
+  it('produces reasonable a key', function() {
+    expect(cacheKey('name', 'dir')).to.eql(cacheKey('name', 'dir'));
+    expect(cacheKey('name', 'dir')).to.not.eql(cacheKey('name', 'dir1'));
+    expect(cacheKey('name', 'dir')).to.not.eql(cacheKey('name1', 'dir'));
+    expect(cacheKey('name', 'dir')).to.not.eql(cacheKey('name1', 'dir1'));
+  });
+});

--- a/tests/cache-test.js
+++ b/tests/cache-test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var expect = require('chai').expect;
+var Cache = require('../lib/cache');
+
+describe('Cache', function() {
+  it('instantiates', function() {
+    expect(new Cache()).to.be.ok;
+  });
+
+  var cache;
+  beforeEach(function() {
+    cache = new Cache();
+  });
+
+  describe('.set .get', function() {
+    it('get (no set)', function() {
+      expect(cache.get('foo')).to.eql(undefined);
+    });
+
+    it('set (no get)', function() {
+      expect(cache.set('foo', 1)).to.eql(1);
+    });
+
+    it('get set get set get', function() {
+      expect(cache.get('foo')).to.eql(undefined);
+      expect(cache.set('foo', 1)).to.eql(1);
+      expect(cache.get('foo')).to.eql(1);
+      expect(cache.set('foo', 2)).to.eql(2);
+      expect(cache.get('foo')).to.eql(2);
+    });
+  });
+
+  describe('.has', function() {
+    it('has no set', function() {
+      expect(cache.has('foo')).to.eql(false);
+    });
+
+   it('has post  set', function() {
+      expect(cache.set('foo', 1)).to.eql(1);
+      expect(cache.has('foo')).to.eql(true);
+
+      expect(cache.set('foo', false)).to.eql(false);
+      expect(cache.has('foo')).to.eql(true);
+
+      expect(cache.set('foo', undefined)).to.eql(undefined);
+      expect(cache.has('foo')).to.eql(true);
+
+      expect(cache.delete('foo')).to.eql(undefined);
+      expect(cache.has('foo')).to.eql(false);
+    });
+  });
+
+  describe('.delete', function() {
+    it('delete no set', function() {
+      expect(cache.has('foo')).to.eql(false);
+      expect(cache.delete('foo')).to.eql(undefined);
+      expect(cache.has('foo')).to.eql(false);
+    });
+
+    it('delete post set', function() {
+      expect(cache.set('foo', 1)).to.eql(1);
+      expect(cache.has('foo')).to.eql(true);
+      expect(cache.delete('foo')).to.eql(undefined);
+      expect(cache.has('foo')).to.eql(false);
+    });
+  });
+});

--- a/tests/cache-test.js
+++ b/tests/cache-test.js
@@ -65,4 +65,25 @@ describe('Cache', function() {
       expect(cache.has('foo')).to.eql(false);
     });
   });
+
+  describe('.size', function() {
+    it('is 0 when empty', function() {
+      expect(cache.size).to.eql(0);
+    });
+
+    it('is 1 when added to', function() {
+      expect(cache.size).to.eql(0);
+      cache.set('fo', 1);
+      expect(cache.size).to.eql(1);
+    });
+
+
+    it('handles deletes', function() {
+      expect(cache.size).to.eql(0);
+      cache.set('fo', 1);
+      expect(cache.size).to.eql(1);
+      cache.delete('fo');
+      expect(cache.size).to.eql(0);
+    });
+  });
 });

--- a/tests/hash-for-dep-test.js
+++ b/tests/hash-for-dep-test.js
@@ -2,10 +2,15 @@
 var path = require('path');
 var assert = require('assert');
 var hashForDep = require('../');
+var expect = require('chai').expect;
 
 var fixturesPath = path.join(__dirname, 'fixtures');
 
 describe('hashForDep', function() {
+  afterEach(function() {
+    hashForDep._resetCache();
+  });
+
   it('Provides a consistent sha1 hash for a dependent package', function() {
     var hashTreeCallCount = 0;
     var hashTreePaths = [
@@ -22,5 +27,34 @@ describe('hashForDep', function() {
 
     assert.equal(hashTreeCallCount, 3, 'hashTree override was called correct number of times');
     assert.equal(result, 'f7ea6f1a10c65f054dc3b094a693b0ff6d8f0fad', 'Expected sha1');
+  });
+
+  describe('cache', function() {
+    it('caches', function() {
+      expect(hashForDep._cache.size).to.eql(0);
+
+      var first = hashForDep('foo', fixturesPath);
+
+      expect(hashForDep._cache.size).to.eql(1);
+
+      var second = hashForDep('foo', fixturesPath);
+
+      expect(first).to.eql(second);
+      expect(hashForDep._cache.size).to.eql(1);
+
+      hashForDep._resetCache();
+
+      expect(hashForDep._cache.size).to.eql(0);
+
+      first = hashForDep('foo', fixturesPath);
+
+      expect(hashForDep._cache.size).to.eql(1);
+
+      second = hashForDep('foo', fixturesPath);
+
+      expect(hashForDep._cache.size).to.eql(1);
+      expect(first).to.eql(second);
+    });
+
   });
 });


### PR DESCRIPTION
By default, cache hash-for-dep per process. I believe this is a safe change, because by default node already caches its modules this way.

* if invoked twice, with the same arguments return the last hash value
* people can opt out of they want
* cache can be evicted entirely (for testing etc)

- [x] make work
- [x] test in real app
- [x] basic TDD
- [x] add missing tests
- [x] heimdalljs logging for hits/misses