### PR TITLE
also cache the tree hash (interior cache)

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function cacheSet(key, value) {
   CACHE[key] = value;
   return value;
 }
+
 /* @public
  *
  * @method hashForDep
@@ -66,7 +67,20 @@ module.exports = function hashForDep(name, dir, _hashTreeOverride, _skipCache) {
 
       heimdallNode.stats.paths++;
 
-      return hashFn(statPath);
+      var key = 'hashOf:' + statPath;
+      var hash;
+
+      if (skipCache === false && CACHE.has(key)) {
+        logger.debug('HIT', key)
+        hash = CACHE.get(key);
+      } else {
+        logger.debug('MISS', key)
+        hash = hashFn(statPath);
+        if (skipCache === false) {
+          CACHE.set(key, hash);
+        }
+      }
+      return hash;
     }).join(0x00);
 
     hash = crypto.createHash('sha1').

--- a/lib/deps-for.js
+++ b/lib/deps-for.js
@@ -2,7 +2,7 @@
 var pkg = require('./pkg');
 
 /* @private
- * 
+ *
  * constructs a set of all dependencies recursively
  *
  * @method depsFor

--- a/lib/stat-paths-for.js
+++ b/lib/stat-paths-for.js
@@ -3,7 +3,7 @@ var pkg = require('./pkg');
 var depsFor = require('./deps-for');
 
 /* @private
- * 
+ *
  * @method statPathsFor
  * @param {String} name
  * @param

--- a/tests/hash-for-dep-test.js
+++ b/tests/hash-for-dep-test.js
@@ -35,12 +35,12 @@ describe('hashForDep', function() {
 
       var first = hashForDep('foo', fixturesPath);
 
-      expect(hashForDep._cache.size).to.eql(1);
+      expect(hashForDep._cache.size).to.eql(4);
 
       var second = hashForDep('foo', fixturesPath);
 
       expect(first).to.eql(second);
-      expect(hashForDep._cache.size).to.eql(1);
+      expect(hashForDep._cache.size).to.eql(4);
 
       hashForDep._resetCache();
 
@@ -48,11 +48,11 @@ describe('hashForDep', function() {
 
       first = hashForDep('foo', fixturesPath);
 
-      expect(hashForDep._cache.size).to.eql(1);
+      expect(hashForDep._cache.size).to.eql(4);
 
       second = hashForDep('foo', fixturesPath);
 
-      expect(hashForDep._cache.size).to.eql(1);
+      expect(hashForDep._cache.size).to.eql(4);
       expect(first).to.eql(second);
     });
 


### PR DESCRIPTION
in addition to caching `hashForDep(name, path)` this PR introduces an interior cache for individual trees. As it turns out, dependencies are often shared, this now ensures deep dependencies hashes are reused. 

The cache is the exact same as the that for hashForDep itself, merely prefixed the keys with `hashFor`. This ensures removal of the primary cache evicts all state. 