### PR TITLE
fix: use resolve with preserveSymlinks = false

### DIFF
--- a/lib/resolve-pkg.js
+++ b/lib/resolve-pkg.js
@@ -17,7 +17,11 @@ module.exports = function resolvePkg(name, dir) {
   if (name === './') {
     return path.resolve(name);
   }
-  return resolve.sync(name, { basedir: dir || __dirname, isFile: isDirectory });
+  return resolve.sync(name, {
+    basedir: dir || __dirname,
+    isFile: isDirectory,
+    preserveSymlinks: false
+  });
 };
 
 function isDirectory(file) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "broccoli-kitchen-sink-helpers": "^0.3.1",
     "heimdalljs": "^0.2.3",
     "heimdalljs-logger": "^0.1.7",
-    "resolve": "^1.1.6"
+    "resolve": "^1.4.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/tests/resolve-pkg-test.js
+++ b/tests/resolve-pkg-test.js
@@ -1,11 +1,35 @@
 'use strict';
+var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var resolvePkg = require('../lib/resolve-pkg');
 
 var fixturesPath = path.join(__dirname, 'fixtures');
 
+var symlinkDir = path.join(fixturesPath, '..', 'symlink');
+
 describe('resolvePkg', function() {
+  before(function () {
+    try {
+      fs.unlinkSync(symlinkDir);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+
+    try {
+        fs.symlinkSync('./fixtures/node_modules/dedupped', symlinkDir, 'dir');
+    } catch (err) {
+        // if fails then it is probably on Windows and lets try to create a junction
+        fs.symlinkSync(path.join(fixturesPath, 'node_modules', 'dedupped') + '\\', symlinkDir, 'junction');
+    }
+  });
+
+  after(function () {
+    fs.unlinkSync(symlinkDir);
+  });
+
   it('Resolves to the absolute main entry point path of the provided package', function() {
     assert.equal(resolvePkg('./'), path.resolve('./'));
     assert.equal(resolvePkg('foo', fixturesPath), path.join(fixturesPath, 'node_modules/foo'));
@@ -14,5 +38,9 @@ describe('resolvePkg', function() {
 
   it('Resolves to the module directory if no main entry is defined', function() {
     assert.equal(resolvePkg('no-main/', fixturesPath), path.join(fixturesPath, 'node_modules/no-main/'));
+  });
+
+  it('Don\'t preserve symlinks when resolving package', function() {
+    assert.equal(resolvePkg('foo', symlinkDir), path.join(fixturesPath, 'node_modules/foo'));
   });
 });


### PR DESCRIPTION
resolve from version 2 will not preserve symlinks by default. This is the way Node resolves dependencies by default as well.

This will make ember work with a symlinked node_modules layout.