### PR TITLE
Handle optionalDependencies.

### DIFF
--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -15,6 +15,8 @@ module.exports = function pkg(name, dir) {
   if (name !== './') { name += '/'; }
 
   var modulePath = resolvePkg(name, dir);
+  if (modulePath === null) { return null; }
+
   var baseDir = moduleBaseDir(modulePath, name);
   var thePackage = require(baseDir + '/package.json');
 

--- a/lib/resolve-pkg.js
+++ b/lib/resolve-pkg.js
@@ -17,11 +17,19 @@ module.exports = function resolvePkg(name, dir) {
   if (name === './') {
     return path.resolve(name);
   }
-  return resolve.sync(name, {
-    basedir: dir || __dirname,
-    isFile: isDirectory,
-    preserveSymlinks: false
-  });
+  try {
+    return resolve.sync(name, {
+      basedir: dir || __dirname,
+      isFile: isDirectory,
+      preserveSymlinks: false
+    });
+  } catch(err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+
+    throw err;
+  }
 };
 
 function isDirectory(file) {

--- a/lib/stat-paths-for.js
+++ b/lib/stat-paths-for.js
@@ -11,6 +11,10 @@ var depsFor = require('./deps-for');
  */
 module.exports = function statPathsFor(name, dir) {
   var thePackage = pkg(name, dir);
+  if (thePackage === null) {
+    // the package was not found, nothing to stat
+    return [];
+  }
   var paths = depsFor(name, dir).
     map(function(dep)     { return dep.baseDir; }).
     filter(function(path) { return 0 !== path.indexOf(thePackage.baseDir); });

--- a/tests/pkg-test.js
+++ b/tests/pkg-test.js
@@ -21,4 +21,8 @@ describe('pkg', function() {
 
     assert.deepEqual(pkg('foo', fixturesPath), expectedPkg);
   });
+
+  it('does not error when package is missing', function() {
+    assert.deepEqual(pkg('derpy-herky', fixturesPath), null);
+  });
 });

--- a/tests/resolve-pkg-test.js
+++ b/tests/resolve-pkg-test.js
@@ -40,6 +40,10 @@ describe('resolvePkg', function() {
     assert.equal(resolvePkg('no-main/', fixturesPath), path.join(fixturesPath, 'node_modules/no-main/'));
   });
 
+  it('does not error if package cannot be found', function() {
+    assert.equal(resolvePkg('cannot-find-me', fixturesPath), null);
+  });
+
   it('Don\'t preserve symlinks when resolving package', function() {
     assert.equal(resolvePkg('foo', symlinkDir), path.join(fixturesPath, 'node_modules/foo'));
   });

--- a/tests/stat-paths-for-test.js
+++ b/tests/stat-paths-for-test.js
@@ -15,4 +15,8 @@ describe('statPathsFor', function() {
 
     assert.deepEqual(statPathsFor('foo', fixturesPath), expectedStatPaths);
   });
+
+  it('should return an empty array when a module cannot be found', function() {
+    assert.deepEqual(statPathsFor('asdfasdf', fixturesPath), []);
+  });
 });


### PR DESCRIPTION
When a package is installed by `npm`, any of its `optionalDependencies` are added to the packages own `dependencies` hash. Unfortunately, this means that we will discover things in `dependencies` that are not _actually_ present in the `node_modules` heirarchy.

This commit handles the specific error condition when a package cannot be found and simply returns `null`, if the package is missing it (by definition) cannot affect the host packages cache key (which is why it is ok to just ignore missing packages).

Fixes #20