### PR TITLE
removed heimdall start/stop in module-entry to cut down on nodes 

### DIFF
--- a/lib/module-entry.js
+++ b/lib/module-entry.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var heimdall = require('heimdalljs');
 var resolvePackagePath = require('./resolve-package-path');
 var cacheKey = require('./cache-key');
 var tryRequire = require('./try-require');
@@ -59,25 +58,20 @@ ModuleEntry.prototype.addDependency = function(dependency, moduleEntry) {
  * in a result object, so we aren't constantly checking that it is set.
  */
 ModuleEntry.prototype._gatherDependencies = function(dependencies) {
-  var h = heimdall.start('hashForDep:ModuleEntry._gatherDependencies');
 
-  try {
-    var moduleEntry = this;
+  var moduleEntry = this;
 
-    if (dependencies[moduleEntry.rootDir] !== undefined) {
-      // we already hit this path during the dependencies somewhere earlier
-      // in the dependency tree, so avoid cycling.
-      return;
-    }
-
-    dependencies[moduleEntry.rootDir] = moduleEntry;
-
-    Object.keys(moduleEntry._dependencies).forEach(function(dep) {
-      moduleEntry._dependencies[dep]._gatherDependencies(dependencies);
-    });
-  } finally {
-    h.stop();
+  if (dependencies[moduleEntry.rootDir] !== undefined) {
+    // we already hit this path during the dependencies somewhere earlier
+    // in the dependency tree, so avoid cycling.
+    return;
   }
+
+  dependencies[moduleEntry.rootDir] = moduleEntry;
+
+  Object.keys(moduleEntry._dependencies).forEach(function(dep) {
+    moduleEntry._dependencies[dep]._gatherDependencies(dependencies);
+  });
 
   return dependencies;
 };
@@ -132,99 +126,94 @@ ModuleEntry.prototype.getHash = function(heimdallNode) {
  * Note this is a class function, not an instance function.
  */
 ModuleEntry.locate = function(caches, name, dir, hashTreeFn) {
-  var h = heimdall.start('hashForDep:ModuleEntry.locate');
   var Constructor = this;
 
-  try {
-    var nameDirKey = cacheKey(name, dir);
-    var realPathKey;
+  var nameDirKey = cacheKey(name, dir);
+  var realPathKey;
 
-    // It's possible that for a given name/dir pair, there is no package.
-    // Record a null entry in CACHES.PATH anyway so we don't need to
-    // redo that search each time.
-    if (caches.PATH.has(nameDirKey)) {
-      realPathKey = caches.PATH.get(nameDirKey);
-      if (realPathKey !== null) {
-        return caches.MODULE_ENTRY.get(realPathKey);
-      } else {
-        return null;
-      }
-    }
-
-    // There is no caches.PATH entry. Try to get a real package.json path. If there
-    // isn't a real path, the name+dir reference is invalid, so note that in caches.PATH.
-    // If there is a real path, check if it is already in the caches.MODULE_ENTRY.
-    // If not, create it and insert it.
-    var realPath = resolvePackagePath(caches, name, dir);
-
-    if (realPath === null) {
-      caches.PATH.set(nameDirKey, null);
+  // It's possible that for a given name/dir pair, there is no package.
+  // Record a null entry in CACHES.PATH anyway so we don't need to
+  // redo that search each time.
+  if (caches.PATH.has(nameDirKey)) {
+    realPathKey = caches.PATH.get(nameDirKey);
+    if (realPathKey !== null) {
+      return caches.MODULE_ENTRY.get(realPathKey);
+    } else {
       return null;
     }
-
-    // We have a path to a file that supposedly is package.json. We need to be sure
-    // that either we already have a caches.MODULE_ENTRY entry (in which case we can
-    // just create a caches.PATH entry to point to it) or that we can read the
-    // package.json file, at which point we can create a caches.MODULE_ENTRY entry,
-    // then finally the new caches.PATH ENTRY.
-
-    // Generate the cache key for a given real file path. This key is then
-    // used as the key for entries in the CacheGroup.MODULE_ENTRY cache
-    // and values in the CacheGroup.PATH cache.
-    realPathKey = cacheKey('hashed:' + realPath, '');
-
-    if (caches.MODULE_ENTRY.has(realPathKey)) {
-      caches.PATH.set(nameDirKey, realPathKey);
-      return caches.MODULE_ENTRY.get(realPathKey);
-    }
-
-    // Require the package.  If we get a 'module-not-found' error it will return null
-    // and we can insert an entry in the cache saying we couldn't find the package
-    // in case it's requested later. Any other more serious error we specifically
-    // don't try to catch here.
-    var thePackage = tryRequire(realPath);
-
-    // if the package was not found, do as above to create a caches.PATH entry
-    // that refers to no path, so we don't waste time doing it again later.
-    if (thePackage === null) {
-      caches.PATH.set(nameDirKey, null);
-      return thePackage;
-    }
-
-    // We have the package object and the relevant keys.
-
-    // Compute the dir containing the package.json,
-    var rootDir = realPath.slice(0, realPath.length - 13);  // length('/package.json') === 13
-
-    // Create and insert the new ModuleEntry into the cache.MODULE_ENTRY
-    // now so we know to stop when dealing with cycles.
-    var moduleEntry = new Constructor(thePackage.name, thePackage.version, rootDir, hashTreeFn(rootDir));
-
-    caches.MODULE_ENTRY.set(realPathKey, moduleEntry);
-    caches.PATH.set(nameDirKey, realPathKey);
-
-    // compute the dependencies here so the ModuleEntry doesn't need to know
-    // about caches or the hashTreeFn or the package and we don't need to
-    // guard against accidental reinitialization of dependencies.
-    if (thePackage.dependencies) {
-      // Recursively locate the references to other moduleEntry objects for the module's
-      // dependencies. Initially we just do the 'local' dependencies (i.e. the ones referenced
-      // in the package.json's 'dependencies' field.) Later, moduleEntry._gatherDependencies
-      // is called to compute the complete list including transitive dependencies, and that
-      // is then used for the final moduleEntry._hash calculation.
-      Object.keys(thePackage.dependencies).sort().forEach(function(dep) {
-        var dependencyModuleEntry = Constructor.locate(caches, dep, rootDir, hashTreeFn);
-
-        // there's not really a good reason to include a failed resolution
-        // of a package in the dependencies list.
-        if (dependencyModuleEntry !== null) {
-          moduleEntry.addDependency(dep, dependencyModuleEntry);
-        }
-      });
-    }
-
-    return moduleEntry;
-  } finally {
-    h.stop();
   }
+
+  // There is no caches.PATH entry. Try to get a real package.json path. If there
+  // isn't a real path, the name+dir reference is invalid, so note that in caches.PATH.
+  // If there is a real path, check if it is already in the caches.MODULE_ENTRY.
+  // If not, create it and insert it.
+  var realPath = resolvePackagePath(caches, name, dir);
+
+  if (realPath === null) {
+    caches.PATH.set(nameDirKey, null);
+    return null;
+  }
+
+  // We have a path to a file that supposedly is package.json. We need to be sure
+  // that either we already have a caches.MODULE_ENTRY entry (in which case we can
+  // just create a caches.PATH entry to point to it) or that we can read the
+  // package.json file, at which point we can create a caches.MODULE_ENTRY entry,
+  // then finally the new caches.PATH ENTRY.
+
+  // Generate the cache key for a given real file path. This key is then
+  // used as the key for entries in the CacheGroup.MODULE_ENTRY cache
+  // and values in the CacheGroup.PATH cache.
+  realPathKey = cacheKey('hashed:' + realPath, '');
+
+  if (caches.MODULE_ENTRY.has(realPathKey)) {
+    caches.PATH.set(nameDirKey, realPathKey);
+    return caches.MODULE_ENTRY.get(realPathKey);
+  }
+
+  // Require the package.  If we get a 'module-not-found' error it will return null
+  // and we can insert an entry in the cache saying we couldn't find the package
+  // in case it's requested later. Any other more serious error we specifically
+  // don't try to catch here.
+  var thePackage = tryRequire(realPath);
+
+  // if the package was not found, do as above to create a caches.PATH entry
+  // that refers to no path, so we don't waste time doing it again later.
+  if (thePackage === null) {
+    caches.PATH.set(nameDirKey, null);
+    return thePackage;
+  }
+
+  // We have the package object and the relevant keys.
+
+  // Compute the dir containing the package.json,
+  var rootDir = realPath.slice(0, realPath.length - 13);  // length('/package.json') === 13
+
+  // Create and insert the new ModuleEntry into the cache.MODULE_ENTRY
+  // now so we know to stop when dealing with cycles.
+  var moduleEntry = new Constructor(thePackage.name, thePackage.version, rootDir, hashTreeFn(rootDir));
+
+  caches.MODULE_ENTRY.set(realPathKey, moduleEntry);
+  caches.PATH.set(nameDirKey, realPathKey);
+
+  // compute the dependencies here so the ModuleEntry doesn't need to know
+  // about caches or the hashTreeFn or the package and we don't need to
+  // guard against accidental reinitialization of dependencies.
+  if (thePackage.dependencies) {
+    // Recursively locate the references to other moduleEntry objects for the module's
+    // dependencies. Initially we just do the 'local' dependencies (i.e. the ones referenced
+    // in the package.json's 'dependencies' field.) Later, moduleEntry._gatherDependencies
+    // is called to compute the complete list including transitive dependencies, and that
+    // is then used for the final moduleEntry._hash calculation.
+    Object.keys(thePackage.dependencies).sort().forEach(function(dep) {
+      var dependencyModuleEntry = Constructor.locate(caches, dep, rootDir, hashTreeFn);
+
+      // there's not really a good reason to include a failed resolution
+      // of a package in the dependencies list.
+      if (dependencyModuleEntry !== null) {
+        moduleEntry.addDependency(dep, dependencyModuleEntry);
+      }
+    });
+  }
+
+  return moduleEntry;
 };

--- a/lib/resolve-package-path.js
+++ b/lib/resolve-package-path.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var fs = require('fs');
-var heimdall = require('heimdalljs');
 var path = require('path');
 var pathRoot = require('path-root');
 
@@ -132,41 +131,35 @@ function _getRealDirectoryPath(realDirectoryPathCache, directoryPath) {
  */
 function _findPackagePath(realFilePathCache, name, dir) {
 
-  var h = heimdall.start('hashForDep:_findPackagePath');
+  var fsRoot = pathRoot(dir);
 
-  try {
-    var fsRoot = pathRoot(dir);
+  var currPath = dir;
 
-    var currPath = dir;
+  while (currPath !== fsRoot) {
+    // when testing for 'node_modules', need to allow names like NODE_MODULES,
+    // which can occur with case-insensitive OSes.
+    var endsWithNodeModules = path.basename(currPath).toLowerCase() === 'node_modules';
 
-    while (currPath !== fsRoot) {
-      // when testing for 'node_modules', need to allow names like NODE_MODULES,
-      // which can occur with case-insensitive OSes.
-      var endsWithNodeModules = path.basename(currPath).toLowerCase() === 'node_modules';
+    var filePath = path.join(currPath, (endsWithNodeModules ? '' : 'node_modules'), name);
 
-      var filePath = path.join(currPath, (endsWithNodeModules ? '' : 'node_modules'), name);
+    var realPath = _getRealFilePath(realFilePathCache, filePath);
 
-      var realPath = _getRealFilePath(realFilePathCache, filePath);
+    if (realPath) {
+      return realPath;
+    }
 
-      if (realPath) {
-        return realPath;
-      }
-
-      if (endsWithNodeModules) {
-        // go up past the ending node_modules directory so the next dirname
-        // goes up past that (if ending in node_modules, going up just one
-        // directory below will then add 'node_modules' on the next loop and
-        // re-process this same node_modules directory.
-        currPath = path.dirname(currPath);
-      }
-
+    if (endsWithNodeModules) {
+      // go up past the ending node_modules directory so the next dirname
+      // goes up past that (if ending in node_modules, going up just one
+      // directory below will then add 'node_modules' on the next loop and
+      // re-process this same node_modules directory.
       currPath = path.dirname(currPath);
     }
 
-    return null;
-  } finally {
-    h.stop();
+    currPath = path.dirname(currPath);
   }
+
+  return null;
 }
 
 /*
@@ -190,44 +183,38 @@ function _findPackagePath(realFilePathCache, name, dir) {
  * resolved using the Node path-normalization rules.
  */
 module.exports = function resolvePackagePath(caches, name, dir) {
-  var h = heimdall.start('hashForDep:resolvePackagePath');
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new TypeError('resolvePackagePath: \'name\' must be a non-zero-length string.');
+  }
 
-  try {
-    if (typeof name !== 'string' || name.length === 0) {
-      throw new TypeError('resolvePackagePath: \'name\' must be a non-zero-length string.');
+  // Perform tests similar to those in resolve.sync(). 
+  var basedir = dir || __dirname;
+
+  // Ensure that basedir is an absolute path at this point.
+  var absoluteStart = path.resolve(basedir);
+
+  // convert absoluteStart to a real path (follow links, etc).
+  absoluteStart = _getRealDirectoryPath(caches.REAL_DIRECTORY_PATH, absoluteStart);
+
+  if (!absoluteStart) {
+    throw new TypeError('resolvePackagePath: \'dir\' must refer to a valid directory name.');
+  }
+
+  if (ABSOLUTE_OR_RELATIVE_PATH_REGEX.test(name)) {
+    // path.resolve() is smart enough that given both absoluteStart and name
+    // if name is itself an absolute path (either Linux or Windows) it will
+    // return that (normalized), ignoring absolutePath. If name is a relative
+    // path, it will be combined with absolutePath and the result normalized.
+    var res = path.resolve(absoluteStart, name);
+    if (name = '..' || name.slice(-1) === '/') {
+      res += '/';  // (path.resolve strips trailing /, add back)
     }
+    return _getRealFilePath(caches.REAL_FILE_PATH, path.join(res, 'package.json'));
 
-    // Perform tests similar to those in resolve.sync(). 
-    var basedir = dir || __dirname;
+    // XXX Do we need to handle the core(x) case too? Not sure.
 
-    // Ensure that basedir is an absolute path at this point.
-    var absoluteStart = path.resolve(basedir);
-
-    // convert absoluteStart to a real path (follow links, etc).
-    absoluteStart = _getRealDirectoryPath(caches.REAL_DIRECTORY_PATH, absoluteStart);
-
-    if (!absoluteStart) {
-      throw new TypeError('resolvePackagePath: \'dir\' must refer to a valid directory name.');
-    }
-
-    if (ABSOLUTE_OR_RELATIVE_PATH_REGEX.test(name)) {
-      // path.resolve() is smart enough that given both absoluteStart and name
-      // if name is itself an absolute path (either Linux or Windows) it will
-      // return that (normalized), ignoring absolutePath. If name is a relative
-      // path, it will be combined with absolutePath and the result normalized.
-      var res = path.resolve(absoluteStart, name);
-      if (name = '..' || name.slice(-1) === '/') {
-        res += '/';  // (path.resolve strips trailing /, add back)
-      }
-      return _getRealFilePath(caches.REAL_FILE_PATH, path.join(res, 'package.json'));
-
-      // XXX Do we need to handle the core(x) case too? Not sure.
-
-    } else {
-      return _findPackagePath(caches.REAL_FILE_PATH, path.join(name, 'package.json'), absoluteStart); 
-    }
-  } finally {
-    h.stop();
+  } else {
+    return _findPackagePath(caches.REAL_FILE_PATH, path.join(name, 'package.json'), absoluteStart); 
   }
 };
 

--- a/tests/fixtures/contains-cycle/is-cycle
+++ b/tests/fixtures/contains-cycle/is-cycle
@@ -1,1 +1,1 @@
-/Users/spenner/src/stefanpenner/hash-for-dep/tests/fixtures/contains-cycle/
+/Users/dcombs/dev/hash-for-dep/tests/fixtures/contains-cycle/


### PR DESCRIPTION
Since hash-for-dep performance is now better, removed the internal heimdall start/stop so that we don't generate quite so many heimdall nodes (tends to overwhelm things when I generate a log of the entries. Left in the start/stop in the index.js file, so we still get nodes for the overall calls.