### PR TITLE
fix broken symlinks error regression

### DIFF
--- a/lib/hash-tree.js
+++ b/lib/hash-tree.js
@@ -10,8 +10,6 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 
-var keysForTreeWarningPrinted;
-
 function getFileInfos(fullPath, _visited) {
   var visited = Array.isArray(_visited) ? _visited : [];
   var realPath = fs.realpathSync(fullPath);
@@ -42,15 +40,8 @@ function getFileInfos(fullPath, _visited) {
       try {
         keys = getFileInfos(path.join(realPath, entry), visited);
       } catch (err) {
-        if (err.code !== 'ENOENT') {
+        if (typeof err === "object" && err !== null && err.code !== 'ENOENT') {
           throw err;
-        }
-
-        if (!keysForTreeWarningPrinted) {
-          console.warn('Warning: failed to stat ' + path.join(fullPath, entry));
-          console.warn('This may be because the file was deleted during the build');
-          console.warn('or is possibly a broken symlink');
-          keysForTreeWarningPrinted = true;
         }
 
         keys = ['missing'];

--- a/lib/hash-tree.js
+++ b/lib/hash-tree.js
@@ -42,6 +42,10 @@ function getFileInfos(fullPath, _visited) {
       try {
         keys = getFileInfos(path.join(realPath, entry), visited);
       } catch (err) {
+        if (err.code !== 'ENOENT') {
+          throw err;
+        }
+
         if (!keysForTreeWarningPrinted) {
           console.warn('Warning: failed to stat ' + path.join(fullPath, entry));
           keysForTreeWarningPrinted = true;

--- a/lib/hash-tree.js
+++ b/lib/hash-tree.js
@@ -10,6 +10,8 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 
+var keysForTreeWarningPrinted;
+
 function getFileInfos(fullPath, _visited) {
   var visited = Array.isArray(_visited) ? _visited : [];
   var realPath = fs.realpathSync(fullPath);
@@ -36,7 +38,20 @@ function getFileInfos(fullPath, _visited) {
         return paths;
       }
 
-      return paths.concat(getFileInfos(path.join(realPath, entry), visited));
+      var keys;
+      try {
+        keys = getFileInfos(path.join(realPath, entry), visited);
+      } catch (err) {
+        if (!keysForTreeWarningPrinted) {
+          console.warn('Warning: failed to stat ' + path.join(fullPath, entry));
+          keysForTreeWarningPrinted = true;
+        }
+        // The child has probably ceased to exist since we called
+        // `readdirSync`, or it is a broken symlink.
+        keys = ['missing'];
+      }
+
+      return paths.concat(keys);
     }, []);
   } else {
     throw new Error('"' + fullPath + '": Unexpected file type');

--- a/lib/hash-tree.js
+++ b/lib/hash-tree.js
@@ -48,10 +48,11 @@ function getFileInfos(fullPath, _visited) {
 
         if (!keysForTreeWarningPrinted) {
           console.warn('Warning: failed to stat ' + path.join(fullPath, entry));
+          console.warn('This may be because the file was deleted during the build');
+          console.warn('or is possibly a broken symlink');
           keysForTreeWarningPrinted = true;
         }
-        // The child has probably ceased to exist since we called
-        // `readdirSync`, or it is a broken symlink.
+
         keys = ['missing'];
       }
 

--- a/tests/fixtures/broken-symlink/broken-symlink
+++ b/tests/fixtures/broken-symlink/broken-symlink
@@ -1,0 +1,1 @@
+does-not-exist

--- a/tests/hash-tree-test.js
+++ b/tests/hash-tree-test.js
@@ -119,8 +119,23 @@ describe('getFileInfos', function() {
 
       fs.symlinkSync(__dirname + '/fixtures/contains-cycle/', __dirname + '/fixtures/contains-cycle/is-cycle');
 
-
       assert.deepEqual(getFileInfos(__dirname + '/fixtures/contains-cycle'), []);
+    });
+
+    it('handles broken symlink', function() {
+      try {
+        fs.unlinkSync(__dirname + '/fixtures/broken-symlink/broken-symlink');
+      } catch (e) {
+        if (typeof e === 'object' && e !== null && e.code === 'ENOENT') {
+          // handle
+        } else {
+          throw e;
+        }
+      }
+
+      fs.symlinkSync('does-not-exist', __dirname + '/fixtures/broken-symlink/broken-symlink');
+
+      assert.deepEqual(getFileInfos(__dirname + '/fixtures/broken-symlink'), ['missing']);
     });
   });
 });


### PR DESCRIPTION
Scenario: You have an addon with a checked-in symlink "some-file => node_modules/some-package/some-file". Your app tries to link to a git branch of your addon. Depending on how npm or yarn structures the node_modules tree, the symlink may be broken. v1.5.0 version of hash-for-dep throws when v1.2.3 didn't.

This is borrowing the code from https://github.com/broccolijs/broccoli-kitchen-sink-helpers/blob/v0.3.1/index.js#L50-L63 that was in use in v1.2.3.

It is not ideal that we have projects with checked-in symlinks, but nevertheless, this fixes the regression.